### PR TITLE
Add preset mask buttons for common facial features

### DIFF
--- a/static/css/components.css
+++ b/static/css/components.css
@@ -116,6 +116,57 @@
     box-shadow: inset 0 2px 4px rgba(0,0,0,0.3);
 }
 
+.preset-btn {
+    background: linear-gradient(135deg, #4CAF50 0%, #45a049 100%);
+    color: white;
+    border: none;
+    padding: 0.6rem 1rem;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 600;
+    transition: all 0.2s;
+    min-width: 80px;
+}
+
+.preset-btn:hover {
+    background: linear-gradient(135deg, #45a049 0%, #3d8b40 100%);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 8px rgba(76, 175, 80, 0.3);
+}
+
+.preset-btn.active {
+    background: linear-gradient(135deg, #2E7D32 0%, #1B5E20 100%);
+    box-shadow: inset 0 2px 4px rgba(0,0,0,0.3);
+    transform: none;
+}
+
+.preset-btn.preset-btn-eyes {
+    background: linear-gradient(135deg, #2196F3 0%, #1976D2 100%);
+}
+
+.preset-btn.preset-btn-eyes:hover {
+    background: linear-gradient(135deg, #1976D2 0%, #1565C0 100%);
+    box-shadow: 0 4px 8px rgba(33, 150, 243, 0.3);
+}
+
+.preset-btn.preset-btn-eyes.active {
+    background: linear-gradient(135deg, #0D47A1 0%, #01579B 100%);
+}
+
+.preset-btn.preset-btn-nose {
+    background: linear-gradient(135deg, #FF9800 0%, #F57C00 100%);
+}
+
+.preset-btn.preset-btn-nose:hover {
+    background: linear-gradient(135deg, #F57C00 0%, #E65100 100%);
+    box-shadow: 0 4px 8px rgba(255, 152, 0, 0.3);
+}
+
+.preset-btn.preset-btn-nose.active {
+    background: linear-gradient(135deg, #E65100 0%, #BF360C 100%);
+}
+
 .upload-area {
     border: 2px dashed #ddd;
     border-radius: 8px;

--- a/static/css/inline-styles.css
+++ b/static/css/inline-styles.css
@@ -54,6 +54,10 @@
     gap: 0.5rem;
 }
 
+.preset-buttons {
+    margin-bottom: 0.5rem;
+}
+
 .action-buttons {
     display: flex;
     gap: 0.5rem;

--- a/static/js/button-handlers.js
+++ b/static/js/button-handlers.js
@@ -13,6 +13,18 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
 
+    // Attach event listeners to preset buttons
+    const presetButtons = document.querySelectorAll('.preset-btn[data-preset]');
+    presetButtons.forEach(button => {
+        button.addEventListener('click', function() {
+            const preset = this.dataset.preset;
+            const imageId = parseInt(this.dataset.imageId);
+            if (preset && imageId) {
+                togglePreset(preset, imageId);
+            }
+        });
+    });
+
     // Clear all masks buttons
     const clearButtons = document.querySelectorAll('.btn-clear-masks');
     clearButtons.forEach(button => {
@@ -35,3 +47,63 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
 });
+
+// Toggle preset mask combinations
+function togglePreset(preset, imageId) {
+    const presets = {
+        'eyes': ['rect_top', 'rect_bottom'],      // Top and bottom bars to focus on eyes
+        'nose': ['rect_left', 'rect_right']       // Left and right bars to focus on nose
+    };
+    
+    if (!presets[preset]) {
+        console.warn('Unknown preset:', preset);
+        return;
+    }
+    
+    const maskTypes = presets[preset];
+    const activeMasks = imageId === 1 ? activeMasks1 : activeMasks2;
+    const presetButton = document.querySelector(`.preset-btn[data-preset="${preset}"][data-image-id="${imageId}"]`);
+    
+    // Check if all masks in the preset are currently active
+    const allActive = maskTypes.every(maskType => activeMasks.has(maskType));
+    
+    if (allActive) {
+        // If all are active, turn them all off
+        maskTypes.forEach(maskType => {
+            if (activeMasks.has(maskType)) {
+                toggleMask(maskType, imageId);
+            }
+        });
+        presetButton.classList.remove('active');
+    } else {
+        // If not all are active, turn them all on
+        maskTypes.forEach(maskType => {
+            if (!activeMasks.has(maskType)) {
+                toggleMask(maskType, imageId);
+            }
+        });
+        presetButton.classList.add('active');
+    }
+    
+    // Update individual button states to reflect the preset change
+    updatePresetButtonStates(imageId);
+}
+
+// Update preset button states based on current mask state
+function updatePresetButtonStates(imageId) {
+    const activeMasks = imageId === 1 ? activeMasks1 : activeMasks2;
+    
+    // Check eyes preset (top + bottom)
+    const eyesButton = document.querySelector(`.preset-btn[data-preset="eyes"][data-image-id="${imageId}"]`);
+    if (eyesButton) {
+        const eyesActive = activeMasks.has('rect_top') && activeMasks.has('rect_bottom');
+        eyesButton.classList.toggle('active', eyesActive);
+    }
+    
+    // Check nose preset (left + right)
+    const noseButton = document.querySelector(`.preset-btn[data-preset="nose"][data-image-id="${imageId}"]`);
+    if (noseButton) {
+        const noseActive = activeMasks.has('rect_left') && activeMasks.has('rect_right');
+        noseButton.classList.toggle('active', noseActive);
+    }
+}

--- a/static/js/mask-operations.js
+++ b/static/js/mask-operations.js
@@ -33,7 +33,7 @@ function toggleMask(maskType, imageNum) {
     }
     
     // Update ALL button appearances (both image sets)
-    const allButtons = document.querySelectorAll(`button[onclick*="toggleMask('${maskType}',"]`);
+    const allButtons = document.querySelectorAll(`button[data-mask-type="${maskType}"].mask-btn`);
     allButtons.forEach(btn => {
         if (activeMasks1.has(maskType)) {
             btn.classList.add('active');
@@ -41,6 +41,10 @@ function toggleMask(maskType, imageNum) {
             btn.classList.remove('active');
         }
     });
+    
+    // Update preset button states
+    updatePresetButtonStates(1);
+    updatePresetButtonStates(2);
     
     // Redraw masks on both images
     redrawMasks(1);
@@ -62,6 +66,12 @@ function clearAllMasks(imageNum) {
     // Update ALL button appearances
     const allButtons = document.querySelectorAll('.mask-btn');
     allButtons.forEach(btn => {
+        btn.classList.remove('active');
+    });
+    
+    // Update preset button states
+    const allPresetButtons = document.querySelectorAll('.preset-btn');
+    allPresetButtons.forEach(btn => {
         btn.classList.remove('active');
     });
     

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,7 +23,13 @@
                     </div>
                     <div class="canvas-controls">
                         <div class="mask-controls">
-                            <div class="mask-controls-title">Mask Areas:</div>
+                            <div class="mask-controls-title">Quick Presets:</div>
+                            <div class="mask-buttons preset-buttons">
+                                <button type="button" class="preset-btn preset-btn-eyes" data-preset="eyes" data-image-id="1">👁️ Eyes</button>
+                                <button type="button" class="preset-btn preset-btn-nose" data-preset="nose" data-image-id="1">👃 Nose</button>
+                            </div>
+                            
+                            <div class="mask-controls-title" style="margin-top: 1rem;">Individual Masks:</div>
                             <div class="mask-buttons">
                                 <button type="button" class="mask-btn mask-btn-purple" data-mask-type="rect_top" data-image-id="1">Top Bar</button>
                                 <button type="button" class="mask-btn mask-btn-purple" data-mask-type="rect_middle" data-image-id="1">Middle Bar</button>
@@ -66,7 +72,13 @@
                     </div>
                     <div class="canvas-controls">
                         <div class="mask-controls">
-                            <div class="mask-controls-title">Mask Areas:</div>
+                            <div class="mask-controls-title">Quick Presets:</div>
+                            <div class="mask-buttons preset-buttons">
+                                <button type="button" class="preset-btn preset-btn-eyes" data-preset="eyes" data-image-id="2">👁️ Eyes</button>
+                                <button type="button" class="preset-btn preset-btn-nose" data-preset="nose" data-image-id="2">👃 Nose</button>
+                            </div>
+                            
+                            <div class="mask-controls-title" style="margin-top: 1rem;">Individual Masks:</div>
                             <div class="mask-buttons">
                                 <button type="button" class="mask-btn mask-btn-purple" data-mask-type="rect_top" data-image-id="2">Top Bar</button>
                                 <button type="button" class="mask-btn mask-btn-purple" data-mask-type="rect_middle" data-image-id="2">Middle Bar</button>


### PR DESCRIPTION
- Add Eyes preset button (toggles top + bottom bars)
- Add Nose preset button (toggles left + right bars)
- Update HTML templates with new preset button sections
- Add JavaScript functionality for preset button logic
- Add CSS styling for preset buttons with distinct colors
- Update mask operations to sync preset button states
- Maintain backward compatibility with individual mask buttons

Features:
- Click "👁️ Eyes" to instantly mask for eye area comparison
- Click "👃 Nose" to instantly mask for nose area comparison
- Preset buttons show active state when all masks are enabled
- Individual mask buttons still work and update preset states
- Clear all button resets both individual and preset buttons

🤖 Generated with [Claude Code](https://claude.ai/code)